### PR TITLE
fix gcc-8 build

### DIFF
--- a/src/inscore2/eval/evaluator2.cpp
+++ b/src/inscore2/eval/evaluator2.cpp
@@ -24,7 +24,7 @@
 */
 
 
-
+#include <functional>
 #include <algorithm>
 #include <sstream>
 #include <string>

--- a/src/inscore2/eval/expandVal.cpp
+++ b/src/inscore2/eval/expandVal.cpp
@@ -24,6 +24,7 @@
 */
 
 #include <sstream>
+#include <functional>
 
 #include "evaluator2.h"
 #include "expandVal.h"


### PR DESCRIPTION
Looking up the build errors I found this [little fix](https://github.com/facebook/rocksdb/commit/816c1e30ca73615c75fc208ddcc4b05012b30951)  

only tested on Ubuntu 18.10
But it now builds and run fine with both guidolib and guidoar on dev branch

